### PR TITLE
Removed extra space in search bar placeholder

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -98,7 +98,7 @@ export default {
     },
     getPlaceholder() {
       var placeholder = `Enter name of song ${
-        this.hideUrlMessage ? "" : " or YouTube URL"
+        this.hideUrlMessage ? "" : "or YouTube URL"
       }`;
       return placeholder;
     }


### PR DESCRIPTION
I removed an extra space, showing in the space bar placeholder.
It was showing `Enter name of song  or YouTube URL` with two space characters between `song` and `or`.

Because it is a simple typo fix, I didn't discuss it first via issue or email. I hope that's alright.
Thanks for your work!